### PR TITLE
Rewrite `get_robotstxt_http_get`

### DIFF
--- a/R/get_robotstxt_http_get.R
+++ b/R/get_robotstxt_http_get.R
@@ -1,53 +1,26 @@
-#' Storage for http request response objects
+#' Storage for HTTP request response objects
 #'
 #' @rdname get_robotstxt_http_get
-#'
 #' @export
-rt_last_http         <- new.env()
+rt_last_http <- new.env()
 rt_last_http$request <- list()
 
 #' Execute HTTP request for get_robotstxt()
 #'
 #' @param ssl_verifypeer either 1 (default) or 0, if 0 it disables SSL peer verification, which
 #'   might help with robots.txt file retrieval
-#' @param domain the domain to get robots.txt. file for
+#' @param domain the domain to get robots.txt file for. Defaults to current version of R
 #' @param user_agent the user agent to use for HTTP request header
-#'
 #' @export
-#'
-get_robotstxt_http_get <-
-  function(
-    domain,
-    user_agent     = utils::sessionInfo()$R.version$version.string,
-    ssl_verifypeer = 1
-  ){
-    # generate url
-    url <- fix_url(paste0(domain, "/robots.txt"))
+get_robotstxt_http_get <- function(domain, user_agent = utils::sessionInfo()$R.version$version.string, ssl_verifypeer = 1) {
+  url <- fix_url(paste0(domain, "/robots.txt"))
+  request <- httr::GET(
+    url = url,
+    config = httr::config(ssl_verifypeer = ssl_verifypeer),
+    httr::add_headers("user-agent" = user_agent)
+  )
 
-    if ( !is.null(user_agent) ) {
-      # with user agent
-      request <-
-        httr::GET(
-          url    = url,
-          config =
-            httr::add_headers(
-              "user-agent" = user_agent
-            ),
-          httr::config(ssl_verifypeer = ssl_verifypeer)
-        )
-    }else{
-      # without user agent
-      request <-
-        httr::GET(
-          url = url,
-          httr::config(ssl_verifypeer = ssl_verifypeer)
-        )
-    }
+  rt_last_http$request <- request
 
-
-    # store in storage
-    rt_last_http$request <- request
-
-    # return
-    request
-  }
+  request
+}

--- a/R/get_robotstxt_http_get.R
+++ b/R/get_robotstxt_http_get.R
@@ -9,15 +9,24 @@ rt_last_http$request <- list()
 #'
 #' @param ssl_verifypeer either 1 (default) or 0, if 0 it disables SSL peer verification, which
 #'   might help with robots.txt file retrieval
-#' @param domain the domain to get robots.txt file for. Defaults to current version of R
-#' @param user_agent the user agent to use for HTTP request header
+#' @param domain the domain to get robots.txt file for.
+#' @param user_agent the user agent to use for HTTP request header. Defaults to current version of R.
+#'   If `NULL` is passed, httr will use software versions for the header, such as
+#'   `libcurl/8.7.1 r-curl/5.2.3 httr/1.4.7`
 #' @export
 get_robotstxt_http_get <- function(domain, user_agent = utils::sessionInfo()$R.version$version.string, ssl_verifypeer = 1) {
   url <- fix_url(paste0(domain, "/robots.txt"))
+
+  headers <- if (!is.null(user_agent)) {
+    httr::add_headers("user-agent" = user_agent)
+  } else {
+    NULL
+  }
+
   request <- httr::GET(
     url = url,
     config = httr::config(ssl_verifypeer = ssl_verifypeer),
-    httr::add_headers("user-agent" = user_agent)
+    headers
   )
 
   rt_last_http$request <- request

--- a/man/get_robotstxt_http_get.Rd
+++ b/man/get_robotstxt_http_get.Rd
@@ -18,9 +18,11 @@ get_robotstxt_http_get(
 )
 }
 \arguments{
-\item{domain}{the domain to get robots.txt file for. Defaults to current version of R}
+\item{domain}{the domain to get robots.txt file for.}
 
-\item{user_agent}{the user agent to use for HTTP request header}
+\item{user_agent}{the user agent to use for HTTP request header. Defaults to current version of R.
+If `NULL` is passed, httr will use software versions for the header, such as
+`libcurl/8.7.1 r-curl/5.2.3 httr/1.4.7`}
 
 \item{ssl_verifypeer}{either 1 (default) or 0, if 0 it disables SSL peer verification, which
 might help with robots.txt file retrieval}

--- a/man/get_robotstxt_http_get.Rd
+++ b/man/get_robotstxt_http_get.Rd
@@ -4,7 +4,7 @@
 \name{rt_last_http}
 \alias{rt_last_http}
 \alias{get_robotstxt_http_get}
-\title{Storage for http request response objects}
+\title{Storage for HTTP request response objects}
 \format{
 An object of class \code{environment} of length 1.
 }
@@ -18,7 +18,7 @@ get_robotstxt_http_get(
 )
 }
 \arguments{
-\item{domain}{the domain to get robots.txt. file for}
+\item{domain}{the domain to get robots.txt file for. Defaults to current version of R}
 
 \item{user_agent}{the user agent to use for HTTP request header}
 
@@ -26,7 +26,7 @@ get_robotstxt_http_get(
 might help with robots.txt file retrieval}
 }
 \description{
-Storage for http request response objects
+Storage for HTTP request response objects
 
 Execute HTTP request for get_robotstxt()
 }


### PR DESCRIPTION
Closes #93. The `user-agent` header by default is set to 
```R
 user_agent = utils::sessionInfo()$R.version$version.string
```
which results in something like `R version 4.4.1 (2024-06-14)`.

The function explicitly adds the header if `user_agent` is not `NULL`. If `NULL` is passed for `user_agent` the header is not explicitly set by the function but a header is still added:
```http
Response [https://httpbin.org/user-agent]
  Date: 2024-11-14 12:46
  Status: 200
  Content-Type: application/json
  Size: 60 B
{
  "user-agent": "libcurl/8.7.1 r-curl/5.2.3 httr/1.4.7"
}
```

So as is, the `if/else` check doesn't do any work and can be dropped.